### PR TITLE
feat: Send selling of player as a notification

### DIFF
--- a/app/utils/sellUtil.js
+++ b/app/utils/sellUtil.js
@@ -1,5 +1,4 @@
 import { convertToSeconds, wait } from "./commonUtil";
-
 import { getSellBidPrice } from "./priceUtils";
 import { getValue } from "../services/repository";
 import { idProgressAutobuyer } from "../elementIds.constants";


### PR DESCRIPTION
### Describe the Feature Request

Currently the notification service only triggers for the buying operations. Similar to the line 

```writeToLog(
    `${playerName}, ${
      message
        ? message
        : sellPrice < 0
        ? "moved to transferlist"
        : shouldList
        ? "selling for: " + sellPrice + ", Profit: " + profit
        : buyerSetting["idAbDontMoveWon"]
        ? ""
        : "moved to club"
    } `,
    idProgressAutobuyer
  );
```

It can be sent in notifications. 

### Describe the Use Case

Allow users to improve leaving the auto buyer on and tracking profits. 

### Describe Preferred Solution

_No response_

### Describe Alternatives

_No response_

### Additional Information

_No response_