### PR TITLE
feat: Allow custom webhook name for servers using multiple traders.

### DIFF
--- a/app/elementIds.constants.js
+++ b/app/elementIds.constants.js
@@ -28,6 +28,7 @@ export const idAbDelayToAdd = "elem_" + generateId(15);
 export const idAbAddFilterGK = "elem_" + generateId(15);
 export const idAbCloseTabToggle = "elem_" + generateId(15);
 export const idAbMessageNotificationToggle = "elem_" + generateId(15);
+export const idAbCustomDiscordNameNotificationToggle = "elem_" + generateId(15);
 export const idAbSoundToggle = "elem_" + generateId(15);
 export const idTelegramBotToken = "elem_" + generateId(15);
 export const idTelegramChatId = "elem_" + generateId(15);

--- a/app/utils/notificationUtil.js
+++ b/app/utils/notificationUtil.js
@@ -1,5 +1,6 @@
-import { getBuyerSettings, setValue, getValue } from "../services/repository";
-import { stopAutoBuyer, startAutoBuyer } from "../handlers/autobuyerProcessor";
+import { getBuyerSettings, getValue, setValue } from "../services/repository";
+import { startAutoBuyer, stopAutoBuyer } from "../handlers/autobuyerProcessor";
+
 import { loadFilter } from "./userExternalUtil";
 
 let discordClient = null;
@@ -33,7 +34,7 @@ const sendNotificationToExternalPhone = (message) => {
 };
 
 const formDiscordMessage = (message, isSuccess) => {
-  return {
+  embedMessage = {
     embeds: [
       {
         description: message,
@@ -49,6 +50,10 @@ const formDiscordMessage = (message, isSuccess) => {
       "https://cdn.discordapp.com/icons/768336764447621122/9de9ea0a7c6239e2f2fbfbd716189e79.webp",
     username: "Fut Market Alert",
   };
+  buyerSetting["idAbCustomDiscordNameNotificationToggle"]
+    ? delete embedMessage["username"]
+    : null;
+  return embedMessage;
 };
 
 const formDiscordRichEmbed = (discordMessage) => {

--- a/app/utils/notificationUtil.js
+++ b/app/utils/notificationUtil.js
@@ -33,8 +33,8 @@ const sendNotificationToExternalPhone = (message) => {
   );
 };
 
-const formDiscordMessage = (message, isSuccess) => {
-  embedMessage = {
+const formDiscordMessage = (message, isSuccess, isCustomDiscordName) => {
+  let embedMessage = {
     embeds: [
       {
         description: message,
@@ -50,9 +50,7 @@ const formDiscordMessage = (message, isSuccess) => {
       "https://cdn.discordapp.com/icons/768336764447621122/9de9ea0a7c6239e2f2fbfbd716189e79.webp",
     username: "Fut Market Alert",
   };
-  buyerSetting["idAbCustomDiscordNameNotificationToggle"]
-    ? delete embedMessage["username"]
-    : null;
+  isCustomDiscordName ? delete embedMessage["username"] : null;
   return embedMessage;
 };
 
@@ -72,9 +70,11 @@ const sendNotificationToExternal = (buyerSetting, isSuccess, message) => {
   const webHookUrl = buyerSetting["idWebHookUrl"];
   const channelId = buyerSetting["idDiscordChannelId"];
   const alertAppNotificationToken = buyerSetting["idFUTMarketAlertToken"];
+  const isCustomDiscordName =
+    buyerSetting["idAbCustomDiscordNameNotificationToggle"];
   sendMessageToTelegram(telegramToken, telegramChatId, message);
-  sendMessageToDiscord(channelId, isSuccess, message);
-  sendMessageToDiscordWH(webHookUrl, isSuccess, message);
+  sendMessageToDiscord(channelId, isSuccess, message, isCustomDiscordName);
+  sendMessageToDiscordWH(webHookUrl, isSuccess, message, isCustomDiscordName);
   sendMessageToAlertApp(alertAppNotificationToken, message);
 };
 
@@ -87,23 +87,37 @@ const sendMessageToTelegram = (telegramToken, telegramChatId, message) => {
   }
 };
 
-const sendMessageToDiscordWH = (webHookUrl, isSuccess, message) => {
+const sendMessageToDiscordWH = (
+  webHookUrl,
+  isSuccess,
+  message,
+  isCustomDiscordName
+) => {
   if (webHookUrl) {
     fetch(webHookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(formDiscordMessage(message, isSuccess)),
+      body: JSON.stringify(
+        formDiscordMessage(message, isSuccess, isCustomDiscordName)
+      ),
     });
   }
 };
 
-const sendMessageToDiscord = (channelId, isSuccess, message) => {
+const sendMessageToDiscord = (
+  channelId,
+  isSuccess,
+  message,
+  isCustomDiscordName
+) => {
   if (channelId) {
     if (discordClient) {
       const channel = discordClient.channels.get(channelId);
       channel &&
         channel.send(
-          formDiscordRichEmbed(formDiscordMessage(message, isSuccess))
+          formDiscordRichEmbed(
+            formDiscordMessage(message, isSuccess, isCustomDiscordName)
+          )
         );
     } else {
       discordClient = initializeDiscordClient(() => {
@@ -112,7 +126,9 @@ const sendMessageToDiscord = (channelId, isSuccess, message) => {
             const channel = discordClient.channels.get(channelId);
             channel &&
               channel.send(
-                formDiscordRichEmbed(formDiscordMessage(message, isSuccess))
+                formDiscordRichEmbed(
+                  formDiscordMessage(message, isSuccess, isCustomDiscordName)
+                )
               );
           }
         }, 200);

--- a/app/views/layouts/Settings/NotificationSettingsView.js
+++ b/app/views/layouts/Settings/NotificationSettingsView.js
@@ -1,22 +1,24 @@
 import {
+  idAbCustomDiscordNameNotificationToggle,
   idAbMessageNotificationToggle,
   idAbSoundToggle,
   idCapatchaMp3,
   idDiscordChannelId,
   idDiscordToken,
   idFUTMarketAlertToken,
+  idFinishMp3,
   idNotificationType,
   idTelegramBotToken,
   idTelegramChatId,
   idTestNotification,
-  idWinMp3,
-  idFinishMp3,
   idWebHookUrl,
+  idWinMp3,
 } from "../../../elementIds.constants";
-import { sendNotificationToUser } from "../../../utils/notificationUtil";
+
 import { generateButton } from "../../../utils/uiUtils/generateButton";
 import { generateTextInput } from "../../../utils/uiUtils/generateTextInput";
 import { generateToggleInput } from "../../../utils/uiUtils/generateToggleInput";
+import { sendNotificationToUser } from "../../../utils/notificationUtil";
 
 export const notificationSettingsView = function () {
   return `<div style='display : none' class='buyer-settings-wrapper notification-settings-view'> 
@@ -99,7 +101,7 @@ export const notificationSettingsView = function () {
     <source src="https://notificationsounds.com/storage/sounds/file-sounds-869-coins.ogg" type="audio/ogg">
     <source src="https://notificationsounds.com/storage/sounds/file-sounds-869-coins.mp3" type="audio/mpeg">
       "Your browser does not support the audio element"
-  </audio> 
+  </audio>
   <audio id='${idCapatchaMp3}' hidden>
     <source src="https://notificationsounds.com/storage/sounds/file-sounds-897-alarm-frenzy.ogg" type="audio/ogg">
     <source src="https://notificationsounds.com/storage/sounds/file-sounds-897-alarm-frenzy.mp3" type="audio/mpeg">
@@ -112,13 +114,19 @@ export const notificationSettingsView = function () {
   </audio> `
        : ""
    }
-   <div class="btn-test-notification buyer-settings-field">  
+     ${generateToggleInput(
+       "Use Custom Discord Bot Name",
+       { idAbCustomDiscordNameNotificationToggle },
+       "",
+       "CommonSettings"
+     )}
+   <div class="btn-test-notification buyer-settings-field">
    ${generateButton(
      idTestNotification,
      "Test Notification",
      () => sendNotificationToUser("Test Notification Message", true, true),
      "call-to-action"
-   )} 
+   )}
    </div>
   `;
 };

--- a/app/views/layouts/Settings/NotificationSettingsView.js
+++ b/app/views/layouts/Settings/NotificationSettingsView.js
@@ -115,7 +115,7 @@ export const notificationSettingsView = function () {
        : ""
    }
      ${generateToggleInput(
-       "Use Custom Discord Bot Name",
+       "Use Custom Discord Webhook Name",
        { idAbCustomDiscordNameNotificationToggle },
        "",
        "CommonSettings"


### PR DESCRIPTION
In my current private server with friends we have a channel where we share the trades the bot is currently performing. The issue with the changes applied today caused the bot to use a new custom username as seen in the screenshot. So allow custom usernames.

![image](https://user-images.githubusercontent.com/59866350/193674654-d09e8fd7-f5ce-4640-a3cd-9dc714915a4b.png)

![image](https://user-images.githubusercontent.com/59866350/193674685-f2e2d596-c906-4820-aeb5-8c9d1056dbc7.png)
